### PR TITLE
Update rubyonrails.yml

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -45,7 +45,6 @@ jobs:
         
       - name: Set up asset pipeline
         run: |
-          yarn build
           yarn build:css
           
       # Add or replace test runners here


### PR DESCRIPTION
removed `yarn build` from asset pipeline setup as that command does not exists in the package.json